### PR TITLE
Fixed replaceHour regex bug

### DIFF
--- a/weather-update/build.gradle
+++ b/weather-update/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.marlan'
-version '2.1.11'
+version '2.1.12'
 
 repositories {
     mavenCentral()

--- a/weather-update/src/main/java/com/marlan/weatherupdate/service/missioneditor/MissionEditor.java
+++ b/weather-update/src/main/java/com/marlan/weatherupdate/service/missioneditor/MissionEditor.java
@@ -133,7 +133,7 @@ public class MissionEditor {
 
     @NotNull
     private String replaceHour(String mission, float hour) {
-        Pattern pattern = Pattern.compile("(?:\\s{4}|\\t)\\[\"start_time\"]\\s=\\s.*,", Pattern.MULTILINE);
+        Pattern pattern = Pattern.compile("^(?:\\s{4}|\\t)\\[\"start_time\"]\\s=\\s.*,$", Pattern.MULTILINE);
         Matcher matcher = pattern.matcher(mission);
         if (!matcher.find()) {
             log.error("Regex match failed, Hour not set.");


### PR DESCRIPTION
The pattern was selecting all the "start_time" lines because I didn't include the "^" in #17. Which could corrupt the mission data.
Not sure why it wasn't here, mb. 
Tested this one in regex101 and it shouldn't select anything except the last one.